### PR TITLE
[imx] Use sorted queue for pts

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
@@ -27,6 +27,7 @@
 #include "threads/CriticalSection.h"
 #include "utils/BitstreamConverter.h"
 
+#include <queue>
 
 //#define IMX_PROFILE
 //#define TRACE_FRAMES
@@ -64,8 +65,6 @@ public:
   bool               Rendered();
   void               Queue(VpuFrameBuffer *buffer);
   VpuDecRetCode      ReleaseFramebuffer(VpuDecHandle *handle);
-  void               SetPts(double pts);
-  double             GetPts(void) const;
 
 protected:
   // private because we are reference counted
@@ -77,7 +76,6 @@ protected:
   long                m_refs;
   VpuFrameBuffer     *m_frameBuffer;
   bool                m_rendered;
-  double              m_pts;
 };
 
 class CDVDVideoCodecIMX : public CDVDVideoCodec
@@ -116,7 +114,6 @@ protected:
   DecMemInfo          m_decMemInfo;        // VPU dedicated memory description
   VpuDecHandle        m_vpuHandle;         // Handle for VPU library calls
   VpuDecInitInfo      m_initInfo;          // Initial info returned from VPU at decoding start
-  bool                m_tsSyncRequired;    // state whether timestamp manager has to be sync'ed
   bool                m_dropState;         // Current drop state
   int                 m_vpuFrameBufferNum; // Total number of allocated frame buffers
   VpuFrameBuffer     *m_vpuFrameBuffers;   // Table of VPU frame buffers description
@@ -125,6 +122,7 @@ protected:
 //  VpuMemDesc         *m_outputBuffers;     // Table of buffers out of VPU (used to call properly VPU_DecOutFrameDisplayed)
   int                 m_frameCounter;      // Decoded frames counter
   bool                m_usePTS;            // State whether pts out of decoding process should be used
+  std::priority_queue<double>         m_pts;
   VpuDecOutFrameInfo  m_frameInfo;
   CBitstreamConverter *m_converter;
   bool                m_convert_bitstream;


### PR DESCRIPTION
The current pts implementation have issues with some h264 where reorder is in function.
The h264 encoding is so that an input frame may need frames before or after it to be rendered. As such, an output frame in ::Decode might be completely unrelated to the current input frame and putting the current input pts is problematic. Furthermore, the input pts are unordered.

As we enable reordering ("m_decOpenParam.nReorderEnable"), we are certain the output frames are in order, but the VPU doesn't give us any mean to know which output frame we are dealing with (big oversight, imo).

This PR creates a pts ordered queue which runs in parallel with the output frame stream.
As 1 input frame = 1 output frame and the output frames are ordered, this solves the problem.

I haven't have much time to test, yet, but seems ok. Please give it a try on your side.

Note: For unknown reason, doing the pts push at "VPU_DecGetConsumedFrameInfo" time produces sync issues. Not sure why....
