### PR TITLE
FIX: [imx] runtime vivante egl extensions

### DIFF
--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
@@ -26,9 +26,6 @@
 #endif
 
 #if HAS_GLES == 2
-#ifdef HAS_IMXVPU
-#define GL_GLEXT_PROTOTYPES
-#endif
 #include "system_gl.h"
 
 #include <locale.h>
@@ -80,9 +77,12 @@ static PFNGLEGLIMAGETARGETTEXTURE2DOESPROC glEGLImageTargetTexture2DOES;
 #endif
 
 #ifdef HAS_IMXVPU
-// GLES extension functions
-#include <GLES2/gl2.h>
-#include <GLES2/gl2ext.h>
+#include "windowing/egl/EGLWrapper.h"
+#define GL_VIV_NV12 0x8FC1
+typedef void (GL_APIENTRYP PFNGLTEXDIRECTVIVMAPPROC) (GLenum Target, GLsizei Width, GLsizei Height, GLenum Format, GLvoid ** Logical, const GLuint * Physical);
+typedef void (GL_APIENTRYP PFNGLTEXDIRECTINVALIDATEVIVPROC) (GLenum Target);
+static PFNGLTEXDIRECTVIVMAPPROC glTexDirectVIVMap;
+static PFNGLTEXDIRECTINVALIDATEVIVPROC glTexDirectInvalidateVIV;
 #endif
 
 #if defined(TARGET_ANDROID)
@@ -160,6 +160,12 @@ CLinuxRendererGLES::CLinuxRendererGLES()
     eglDestroyImageKHR = (PFNEGLDESTROYIMAGEKHRPROC) CEGLWrapper::GetProcAddress("eglDestroyImageKHR");
   if (!glEGLImageTargetTexture2DOES)
     glEGLImageTargetTexture2DOES = (PFNGLEGLIMAGETARGETTEXTURE2DOESPROC) CEGLWrapper::GetProcAddress("glEGLImageTargetTexture2DOES");
+#endif
+#ifdef HAS_IMXVPU
+  if (!glTexDirectVIVMap)
+    glTexDirectVIVMap = (PFNGLTEXDIRECTVIVMAPPROC) CEGLWrapper::GetProcAddress("glTexDirectVIVMap");
+  if (!glTexDirectInvalidateVIV)
+    glTexDirectInvalidateVIV = (PFNGLTEXDIRECTINVALIDATEVIVPROC) CEGLWrapper::GetProcAddress("glTexDirectInvalidateVIV");
 #endif
 }
 


### PR DESCRIPTION
As there seem to be issues on how to define the vivante egl extensions depending on the toolchains used, this hardcode the definitions and do runtime resolution.

This will probably be easier for android, anyway.
