### PR TITLE
FIX: cross-complation

### DIFF
--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -928,8 +928,10 @@ int CXBMCRenderManager::AddVideoPicture(DVDVideoPicture& pic)
   else if(pic.format == RENDER_FMT_MEDIACODEC)
     m_pRenderer->AddProcessor(pic.mediacodec, index);
 #endif
+#ifdef HAS_IMXVPU
   else if(pic.format == RENDER_FMT_YV12_BUFFER || pic.format == RENDER_FMT_IMXMAP)
     m_pRenderer->AddProcessor(pic.codecinfo, index);
+#endif
 
   m_pRenderer->ReleaseImage(index, false);
 


### PR DESCRIPTION
Fixes xbmc compilation on (at least) win32. Unrelated to imx self but obviously needed for XBMC merging ;)
