### PR TITLE
Vsync discussion

### DIFF
--- a/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
@@ -29,7 +29,9 @@
 #include "utils/log.h"
 #include "utils/RegExp.h"
 #include "utils/StringUtils.h"
+#include "utils/Environment.h"
 #include "guilib/gui3d.h"
+#include "windowing/WindowingFactory.h"
 
 CEGLNativeTypeIMX::CEGLNativeTypeIMX()
 {
@@ -118,6 +120,9 @@ void CEGLNativeTypeIMX::Destroy()
 
 bool CEGLNativeTypeIMX::CreateNativeDisplay()
 {
+  // Force double-buffering
+  CEnvironment::setenv("FB_MULTI_BUFFER", "2", 0);
+
   // EGL will be rendered on fb0
   m_display = fbGetDisplayByIndex(0);
   m_nativeDisplay = &m_display;
@@ -219,7 +224,12 @@ bool CEGLNativeTypeIMX::GetPreferredResolution(RESOLUTION_INFO *res) const
 
 bool CEGLNativeTypeIMX::ShowWindow(bool show)
 {
-  // CLog::Log(LOGERROR, "%s - call CEGLNativeTypeIMX::ShowWindow with %d.\n", __FUNCTION__, show);
+  // Force vsync by default
+  eglSwapInterval(g_Windowing.GetEGLDisplay(), 1);
+  EGLint result = eglGetError();
+  if(result != EGL_SUCCESS)
+    CLog::Log(LOGERROR, "EGL error in %s: %x",__FUNCTION__, result);
+
   return false;
 }
 

--- a/xbmc/windowing/egl/WinSystemEGL.cpp
+++ b/xbmc/windowing/egl/WinSystemEGL.cpp
@@ -306,7 +306,9 @@ bool CWinSystemEGL::DestroyWindow()
 bool CWinSystemEGL::ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop)
 {
   CRenderSystemGLES::ResetRenderSystem(newWidth, newHeight, true, 0);
-  SetVSyncImpl(m_iVSyncMode);
+  int vsync_mode = CSettings::Get().GetInt("videoscreen.vsync");
+  if (vsync_mode != VSYNC_DRIVER)
+    SetVSyncImpl(m_iVSyncMode);
   return true;
 }
 
@@ -314,7 +316,9 @@ bool CWinSystemEGL::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
 {
   CreateNewWindow("", fullScreen, res, NULL);
   CRenderSystemGLES::ResetRenderSystem(res.iWidth, res.iHeight, fullScreen, res.fRefreshRate);
-  SetVSyncImpl(m_iVSyncMode);
+  int vsync_mode = CSettings::Get().GetInt("videoscreen.vsync");
+  if (vsync_mode != VSYNC_DRIVER)
+    SetVSyncImpl(m_iVSyncMode);
   return true;
 }
 


### PR DESCRIPTION
Those patches gives me flawless vsync with the 3.10 gpu libraries. Mileage could vary on the stable libs though, so probably has to be discussed

The first commit is actually an xbmc bug that I'll upstream ;)
The second one forces the use of vsync. I'm not sure anyone would actually want _not_ having vsync enabled. It doesn't overwrite an existing FB_MULTI_BUFFER variable, for those needing 3.

It is _very_ important (at least on my system) to keep the XBMC vsync setting on "Driver". Any other setting sooner or latter leads to a deadlock, probably due to the fact that xbmc is strangely doing the "eglSwapInterval" (i.e. enables vsync) for each and every frame ;)

On a side note, with this solved, the cubox-i has now become my daily device ;)
