### PR TITLE
FIX: [imx] force mod 16 output frame size

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
@@ -684,6 +684,11 @@ int CDVDVideoCodecIMX::Decode(BYTE *pData, int iSize, double dts, double pts)
           CLog::Log(LOGERROR, "%s - VPU Cannot get output frame(%d).\n", __FUNCTION__, ret);
           goto out_error;
         }
+
+        // Some codecs (VC1?) lie about their frame size (mod 16). Adjust...
+        m_frameInfo.pExtInfo->nFrmWidth  = (((m_frameInfo.pExtInfo->nFrmWidth) + 15) & ~15);
+        m_frameInfo.pExtInfo->nFrmHeight = (((m_frameInfo.pExtInfo->nFrmHeight) + 15) & ~15);
+
         retStatus |= VC_PICTURE;
       } //VPU_DEC_OUTPUT_DIS
 


### PR DESCRIPTION
Some codecs lie about their frame size, apparently ;)
