### PR TITLE
fix CheckCompatibility for newer kernel

### DIFF
--- a/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
@@ -44,7 +44,7 @@ CEGLNativeTypeIMX::~CEGLNativeTypeIMX()
 bool CEGLNativeTypeIMX::CheckCompatibility()
 {
   std::string strName;
-  std::string str2 ("mxc");
+  std::string str2 ("mxc_sdc_fb");
   get_sysfs_str("/sys/class/graphics/fb0/device/modalias", strName);
   StringUtils::Trim(strName);
   size_t found = strName.find(str2);

--- a/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
@@ -44,9 +44,11 @@ CEGLNativeTypeIMX::~CEGLNativeTypeIMX()
 bool CEGLNativeTypeIMX::CheckCompatibility()
 {
   std::string strName;
+  std::string str2 ("mxc");
   get_sysfs_str("/sys/class/graphics/fb0/device/modalias", strName);
   StringUtils::Trim(strName);
-  if (strName == "platform:mxc_sdc_fb")
+  size_t found = strName.find(str2);
+  if (found!=std::string::npos)
     return true;
   return false;
 }


### PR DESCRIPTION
on newer kernel (3.10.30),
 cat  /sys/class/graphics/fb0/device/modalias returns "platform:mxc_sdc_fb.28"
