### PR TITLE
[imx] Move deinterlacing into render thread and use gui settings

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
@@ -890,6 +890,15 @@ bool CDVDVideoCodecIMX::ClearPicture(DVDVideoPicture* pDvdVideoPicture)
 
 bool CDVDVideoCodecIMX::GetPicture(DVDVideoPicture* pDvdVideoPicture)
 {
+#ifdef IMX_PROFILE
+  static unsigned int previous = 0;
+  unsigned int current;
+
+  current = XbmcThreads::SystemClockMillis();
+  CLog::Log(LOGDEBUG, "%s  tm:%03d\n", __FUNCTION__, current - previous);
+  previous = current;
+#endif
+
   m_frameCounter++;
 
   pDvdVideoPicture->iFlags = DVP_FLAG_ALLOCATED;
@@ -1028,8 +1037,8 @@ bool CDVDVideoCodecIMXBuffer::Rendered() const
 
 void CDVDVideoCodecIMXBuffer::Queue(VpuDecOutFrameInfo *frameInfo)
 {
-  // No lock necessary because at the time Queue there is definitely no
-  // thread that is still holding a reference
+  // No lock necessary because at this time there is definitely no
+  // thread still holding a reference
   m_frameBuffer = frameInfo->pDisplayFrameBuf;
   m_rendered = false;
 
@@ -1363,7 +1372,7 @@ bool CDVDVideoCodecIPUBuffers::Reset()
     m_buffers[i]->ReleaseFrameBuffer();
 }
 
-bool CDVDVideoCodecIPUBuffers::SetEnabled(bool enabled)
+void CDVDVideoCodecIPUBuffers::SetEnabled(bool enabled)
 {
   m_bEnabled = enabled;
 }

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
@@ -75,6 +75,7 @@ protected:
   // private because we are reference counted
   virtual                  ~CDVDVideoCodecIMXBuffer();
 
+private:
 #ifdef TRACE_FRAMES
   int                      m_idx;
 #endif
@@ -136,12 +137,14 @@ class CDVDVideoCodecIPUBuffers
 
     bool Init(int width, int height, int numBuffers, int nAlign);
     bool Reset();
+    bool SetEnabled(bool);
     bool Close();
 
     CDVDVideoCodecIPUBuffer *Process(CDVDVideoCodecBuffer *sourceBuffer,
                                      VpuFieldType fieldType, bool lowMotion);
 
   private:
+    bool                      m_bEnabled;
     int                       m_ipuHandle;
     int                       m_bufferNum;
     CDVDVideoCodecIPUBuffer **m_buffers;
@@ -168,6 +171,9 @@ public:
   virtual void SetDropState(bool bDrop);
   virtual const char* GetName(void) { return (const char*)m_pFormatName; }
   virtual unsigned GetAllowedReferences();
+
+  static void Enter();
+  static void Leave();
 
 protected:
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
@@ -137,7 +137,7 @@ class CDVDVideoCodecIPUBuffers
 
     bool Init(int width, int height, int numBuffers, int nAlign);
     bool Reset();
-    bool SetEnabled(bool);
+    void SetEnabled(bool);
     bool Close();
 
     CDVDVideoCodecIPUBuffer *Process(CDVDVideoCodecBuffer *sourceBuffer,

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
@@ -137,14 +137,12 @@ class CDVDVideoCodecIPUBuffers
 
     bool Init(int width, int height, int numBuffers, int nAlign);
     bool Reset();
-    void SetEnabled(bool);
     bool Close();
 
     CDVDVideoCodecIPUBuffer *Process(CDVDVideoCodecBuffer *sourceBuffer,
                                      VpuFieldType fieldType, bool lowMotion);
 
   private:
-    bool                      m_bEnabled;
     int                       m_ipuHandle;
     int                       m_bufferNum;
     CDVDVideoCodecIPUBuffer **m_buffers;


### PR DESCRIPTION
This moves deinterlacing into the render thread and uses the GUI settings to configure deinterlacing during runtime.
