### PR TITLE
[imx] attempt to recover audio from resolution change

### DIFF
--- a/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
@@ -32,6 +32,7 @@
 #include "utils/Environment.h"
 #include "guilib/gui3d.h"
 #include "windowing/WindowingFactory.h"
+#include "cores/AudioEngine/AEFactory.h"
 
 CEGLNativeTypeIMX::CEGLNativeTypeIMX()
 {
@@ -194,6 +195,10 @@ bool CEGLNativeTypeIMX::SetNativeResolution(const RESOLUTION_INFO &res)
   CreateNativeDisplay();
 
   CLog::Log(LOGDEBUG, "%s: %s",__FUNCTION__, res.strId.c_str());
+
+  // Reset AE
+  CAEFactory::DeviceChange();
+
   return true;
 }
 


### PR DESCRIPTION
This fixes the problem I had with HDMI passthrough producing only static after a resolution change.
Please test it on analog (and spdif, if someone is using it)
