### PR TITLE
Handle dts properly

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
@@ -178,6 +178,7 @@ protected:
   int  VpuFindBuffer(void *frameAddr);
 
   static const int    m_extraVpuBuffers;   // Number of additional buffers for VPU
+  static const int    m_maxVpuDecodeLoops; // Maximum iterations in VPU decoding loop
   static CCriticalSection m_codecBufferLock;
 
   CDVDStreamInfo      m_hints;             // Hints from demuxer at stream opening
@@ -202,4 +203,5 @@ protected:
   int                 m_bytesToBeConsumed; // Remaining bytes in VPU
   double              m_previousPts;       // Enable to keep pts when needed
   bool                m_frameReported;     // State whether the frame consumed event will be reported by libfslvpu
+  double              m_dts;               // Current dts
 };


### PR DESCRIPTION
This PR is the consequence of discussions in #32 and #46,

The fixdts3 branch is an update of fixdts2 which limits the number of decoding loops.
As a reminder it will : 
- enable to call VPU_DecDecodeBuf more than 2 times per  ::Decode call.
- returns dts instead of NOPTS when no pts is available

(more details are available in this [comment](https://github.com/xbmc-imx6/xbmc/pull/46#issuecomment-38121275))
