### PR TITLE
Fix "'uint' does not name a type" when using linux/mxcfb.h

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
@@ -26,6 +26,7 @@
 #include <sys/ioctl.h>
 #include <unistd.h>
 #include <sys/mman.h>
+#include <sys/types.h>
 #include <linux/mxcfb.h>
 #include <linux/ipu.h>
 #include "threads/SingleLock.h"

--- a/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
@@ -18,6 +18,7 @@
  *
  */
 
+#include <sys/types.h>
 #include <linux/mxcfb.h>
 #include "system.h"
 #include <EGL/egl.h>


### PR DESCRIPTION
When trying to compile, it fails with this error:

```
/usr/include/linux/mxcfb.h:113:2: error: 'uint' does not name a type
```

This fixes it.
