### PR TITLE
Fixes wong data access when converting 24bit/3byte samples to floating point

### DIFF
--- a/xbmc/cores/AudioEngine/Utils/AEConvert.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEConvert.cpp
@@ -244,7 +244,7 @@ unsigned int CAEConvert::S24BE3_Float(uint8_t *data, const unsigned int samples,
 {
   for (unsigned int i = 0; i < samples; ++i, data += 3)
   {
-    int s = (data[1] << 24) | (data[2] << 16) | (data[3] << 8);
+    int s = (data[0] << 24) | (data[1] << 16) | (data[2] << 8);
     *dest++ = (float)s * INT32_SCALE;
   }
   return samples;


### PR DESCRIPTION
We need to read bytes 0..2 instead of 1..3.
