### PR TITLE
Reenable periodic input devices checks

### DIFF
--- a/xbmc/input/linux/LinuxInputDevices.cpp
+++ b/xbmc/input/linux/LinuxInputDevices.cpp
@@ -1228,7 +1228,7 @@ XBMC_Event CLinuxInputDevices::ReadEvent()
     if ((now - m_lastHotplugCheck) >= 10)
     {
       // Comment for now as it has visible issue on video decoding when USB devices are available
-      //CheckHotplugged();
+      CheckHotplugged();
       m_lastHotplugCheck = now;
     }
   }


### PR DESCRIPTION
Since Chris added probe (with stat) before trying to open input devices, we can reenable periodic checks with no lag
(Sorry long forgotten stuff...)
