### PR TITLE
HD audio : Relax m_frames check

### DIFF
--- a/xbmc/cores/AudioEngine/AESinkFactory.cpp
+++ b/xbmc/cores/AudioEngine/AESinkFactory.cpp
@@ -132,7 +132,7 @@ IAESink *CAESinkFactory::TrySink(std::string &driver, std::string &device, AEAud
       CLog::Log(LOGERROR, "Sink %s:%s returned invalid sample rate", driver.c_str(), device.c_str());
     else if (format.m_channelLayout.Count() == 0)
       CLog::Log(LOGERROR, "Sink %s:%s returned invalid channel layout", driver.c_str(), device.c_str());
-    else if (format.m_frames < 256)
+    else if (format.m_frames < 192)
       CLog::Log(LOGERROR, "Sink %s:%s returned invalid buffer size: %d", driver.c_str(), device.c_str(), format.m_frames);
     else
       return sink;

--- a/xbmc/cores/AudioEngine/AESinkFactory.cpp
+++ b/xbmc/cores/AudioEngine/AESinkFactory.cpp
@@ -132,7 +132,7 @@ IAESink *CAESinkFactory::TrySink(std::string &driver, std::string &device, AEAud
       CLog::Log(LOGERROR, "Sink %s:%s returned invalid sample rate", driver.c_str(), device.c_str());
     else if (format.m_channelLayout.Count() == 0)
       CLog::Log(LOGERROR, "Sink %s:%s returned invalid channel layout", driver.c_str(), device.c_str());
-    else if (format.m_frames < 192)
+    else if (format.m_frames < 96)
       CLog::Log(LOGERROR, "Sink %s:%s returned invalid buffer size: %d", driver.c_str(), device.c_str(), format.m_frames);
     else
       return sink;


### PR DESCRIPTION
To enable period size used by HD HDMI and by multichannel PCM as mentioned in #68
