### PR TITLE
Imx6 fixes, IMX6 audio hdmi support

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -1079,12 +1079,17 @@ void CAESinkALSA::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
   snd_config_t *config;
   snd_config_copy(&config, snd_config);
 
+#ifndef HAS_IMXFB
   /* Always enumerate the default device.
    * Note: If "default" is a stereo device, EnumerateDevice()
    * will automatically add "@" instead to enable surroundXX mangling.
    * We don't want to do that if "default" can handle multichannel
    * itself (e.g. in case of a pulseaudio server). */
+
+  /* For IMX6, we do not enurate default device as it will be grabbed
+   * as one of the sysdefault devices... */
   EnumerateDevice(list, "default", "", config);
+#endif
 
   void **hints;
 
@@ -1136,7 +1141,10 @@ void CAESinkALSA::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
        * "plughw", "dsnoop"). */
 
       else if (baseName != "default"
+#ifndef HAS_IMXFB
+            /* For wandboard all devices are prefixed by sysdefault so do not ignore them */
             && baseName != "sysdefault"
+#endif
             && baseName != "surround40"
             && baseName != "surround41"
             && baseName != "surround50"
@@ -1245,6 +1253,23 @@ void CAESinkALSA::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
 
 AEDeviceType CAESinkALSA::AEDeviceTypeFromName(const std::string &name)
 {
+#ifdef HAS_IMXFB
+  std::size_t found;
+
+  /* Hack : Check for specific wandboard sound device names */
+  found = name.find("imxspdif");
+  if (found!=std::string::npos)
+    return AE_DEVTYPE_IEC958;
+
+  found = name.find("imxhdmisoc");
+  if (found!=std::string::npos)
+    return AE_DEVTYPE_HDMI;
+
+  found = name.find("sgtl5000audio");
+  if (found!=std::string::npos)
+    return AE_DEVTYPE_PCM;
+#endif
+
   if (name.substr(0, 4) == "hdmi")
     return AE_DEVTYPE_HDMI;
   else if (name.substr(0, 6) == "iec958" || name.substr(0, 5) == "spdif")

--- a/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
@@ -211,8 +211,7 @@ bool CEGLNativeTypeIMX::ProbeResolutions(std::vector<RESOLUTION_INFO> &resolutio
 
   std::string valstr;
   get_sysfs_str("/sys/class/graphics/fb0/modes", valstr);
-  std::vector<CStdString> probe_str;
-  StringUtils::SplitString(valstr, "\n", probe_str);
+  std::vector<std::string> probe_str = StringUtils::Split(valstr, "\n");
 
   resolutions.clear();
   RESOLUTION_INFO res;


### PR DESCRIPTION
This PR fixes a build issue after https://github.com/xbmc-imx6/xbmc/commit/74f3f02 and adds HDMI audio support (found in master-pr before the last rebase, added ifdef's for imx)
