### PR TITLE
Remove specific audio changes

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -720,10 +720,7 @@ void CAESinkALSA::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
    * will automatically add "@" instead to enable surroundXX mangling.
    * We don't want to do that if "default" can handle multichannel
    * itself (e.g. in case of a pulseaudio server). */
-
-  /* For Wandboard, we do not enurate default device as it will be grabbed
-   * as one of the sysdefault devices... */
-
+  EnumerateDevice(list, "default", "", config);
 
   void **hints;
 
@@ -774,8 +771,8 @@ void CAESinkALSA::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
        * found by the enumeration process. Skip them as well ("hw", "dmix",
        * "plughw", "dsnoop"). */
 
-      /* For wandboard all devices are prefixed by sysdefault so do not ignore them */
       else if (baseName != "default"
+            && baseName != "sysdefault"
             && baseName != "surround40"
             && baseName != "surround41"
             && baseName != "surround50"
@@ -884,22 +881,6 @@ void CAESinkALSA::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
 
 AEDeviceType CAESinkALSA::AEDeviceTypeFromName(const std::string &name)
 {
-  std::size_t found;
-
-  /* Hack : Check for specific wandboard sound device names */
-  found = name.find("imxspdif");
-  if (found!=std::string::npos)
-    return AE_DEVTYPE_IEC958;
-
-  found = name.find("imxhdmisoc");
-  if (found!=std::string::npos)
-    return AE_DEVTYPE_HDMI;
-
-  found = name.find("sgtl5000audio");
-  if (found!=std::string::npos)
-    return AE_DEVTYPE_PCM;
-
-
   if (name.substr(0, 4) == "hdmi")
     return AE_DEVTYPE_HDMI;
   else if (name.substr(0, 6) == "iec958" || name.substr(0, 5) == "spdif")


### PR DESCRIPTION
Alsa configurations enable to avoid them
For configuration instances you can check:
https://github.com/OpenBricks/openbricks/blob/master/packages/sound/alsa-lib/config/imx-spdif.conf
https://github.com/OpenBricks/openbricks/blob/master/packages/sound/alsa-lib/config/imx-hdmi-soc.conf

As alluded in #14 #62 and https://github.com/xbmc-imx6/xbmc/issues/68#issuecomment-51150477
it is for master and master-pr 
but I have already pushed it in the master-pr I am working on (sorry I was not able to get committed to the task this WE but I will on monday as I am on holidays)
